### PR TITLE
Fix error during setup "[...] DatacenterViewInstaller [...] Unknown attribute locationtype_id from class Location"

### DIFF
--- a/dist/molkobain-datacenter-view-bridge-for-combodo-location-hierarchy/datamodel.molkobain-datacenter-view-bridge-for-combodo-location-hierarchy.xml
+++ b/dist/molkobain-datacenter-view-bridge-for-combodo-location-hierarchy/datamodel.molkobain-datacenter-view-bridge-for-combodo-location-hierarchy.xml
@@ -32,6 +32,19 @@
 				</list>
 			</presentation>
 		</class>
+    <class id="LocationType">
+      <fields>
+        <field id="locations_list"  _delta="delete_if_exists" />
+      </fields>
+      <presentation>
+        <details>
+          <items>
+            <item id="locations_list" _delta="delete_if_exists">
+            </item>
+          </items>
+        </details>
+      </presentation>
+    </class>
 	</classes>
 	<!--
 	<user_rights>


### PR DESCRIPTION
Fix this error during setup :
![image](https://github.com/user-attachments/assets/c6d0f2d9-6410-4dd0-9e0f-43564fedef79)
with the extensions : combodo-location-hierarchy and molkobain-datacenter-view-extended
